### PR TITLE
Show startup error in console

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,4 +23,10 @@ require('./app')(config, function (err, app) {
 	console.log(chalk.underline.cyan('pa11y-webservice started'));
 	console.log(chalk.grey('mode: %s'), process.env.NODE_ENV);
 	console.log(chalk.grey('uri:  %s'), app.server.info.uri);
+	
+	if (err) {
+		console.error('');
+		console.error(chalk.red('Error starting pa11y-webservice:'));
+		console.error(err.message);
+	}
 });


### PR DESCRIPTION
If there is an error on startup (such as no MongoDB available on the configured host/port) shows the error message in the console.

Maybe fixes this issue: https://github.com/springernature/pa11y-webservice/issues/7