### PR TITLE
Make 'npm start' do 'node index.js' instead of 'node .'

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 
 	"main": "./app.js",
 	"scripts": {
-		"start": "node .",
+		"start": "node index.js",
 		"test": "grunt"
 	}
 }


### PR DESCRIPTION
`node index.js` starts the web service, whereas `node .` doesn't. So I changed it for deploying to hosts that expect `npm start` to start the app (in my case, I'm deploying to heroku).

I'm not actually sure what `node .` does, am I missing something?