### PR TITLE
Configuration by environment variables

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,14 +13,21 @@
 // You should have received a copy of the GNU General Public License
 // along with pa11y-webservice.  If not, see <http://www.gnu.org/licenses/>.
 
-'use strict';
+var fs = require('fs');
+var jsonPath = './config/' + (process.env.NODE_ENV || 'development') + '.json';
 
-var chalk = require('chalk');
-var config = require('./config');
+if (fs.existsSync(jsonPath)) {
+  module.exports = require(jsonPath);
+} else {
+  module.exports = {
+    database: env('DATABASE', 'mongodb://localhost/pa11y-webservice'),
+    host: env('HOST', '0.0.0.0'),
+    port: Number(env('PORT', '3000')),
+    cron: env('CRON', false)
+  }
+}
 
-require('./app')(config, function (err, app) {
-	console.log('');
-	console.log(chalk.underline.cyan('pa11y-webservice started'));
-	console.log(chalk.grey('mode: %s'), process.env.NODE_ENV);
-	console.log(chalk.grey('uri:  %s'), app.server.info.uri);
-});
+function env(name, defaultValue) {
+  var value = process.env[name];
+  return typeof value == 'string' ? value : defaultValue;
+}


### PR DESCRIPTION
Allow configuration via environment variables (as an optional alternative to a configuration file) so that pa11y-webservice can be set up easily on hosts with read-only file systems, like heroku.