### PR TITLE
allow http basic auth if username/password present

### DIFF
--- a/model/task.js
+++ b/model/task.js
@@ -160,7 +160,7 @@ module.exports = function(app, callback) {
 							log: pa11yLog
 						}
 					};
-					if (!task.username && !task.password) {
+					if (task.username && task.password) {
 						pa11yOptions.page = {
 							settings: {
 								userName: task.username,


### PR DESCRIPTION
was using pa11y-webservice indirectly via dashboard.  it seemed as if any username/password values for http basic auth was ignored when provided.  this quick & dirty fix addresses, although a more appropriate check might be to also check if not undefined and null or (in retrospect) using !! for both username & password.