### PR TITLE
enabled --wait option to new task and edit task commands in web service

### DIFF
--- a/model/task.js
+++ b/model/task.js
@@ -95,6 +95,7 @@ module.exports = function(app, callback) {
 				var taskEdits = {
 					name: edits.name,
 					timeout: parseInt(edits.timeout, 10),
+					wait: parseInt(edits.wait, 10),
 					username: edits.username,
 					password: edits.password
 				};
@@ -152,6 +153,7 @@ module.exports = function(app, callback) {
 					var pa11yOptions = {
 						standard: task.standard,
 						timeout: (task.timeout || 30000),
+						wait: (task.wait || 0),
 						ignore: task.ignore,
 						phantom: {},
 						log: {
@@ -198,6 +200,7 @@ module.exports = function(app, callback) {
 					name: task.name,
 					url: task.url,
 					timeout: (task.timeout ? parseInt(task.timeout, 10) : 30000),
+					wait: (task.wait ? parseInt(task.wait, 10) : 0),
 					standard: task.standard,
 					ignore: task.ignore || []
 				};

--- a/model/task.js
+++ b/model/task.js
@@ -12,6 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with pa11y-webservice.  If not, see <http://www.gnu.org/licenses/>.
+/*jshint maxcomplexity:7*/
 
 'use strict';
 

--- a/route/task.js
+++ b/route/task.js
@@ -101,6 +101,7 @@ module.exports = function(app) {
 					payload: {
 						name: Hapi.types.String().required(),
 						timeout: Hapi.types.Number().integer(),
+						wait: Hapi.types.Number().integer(),
 						ignore: Hapi.types.Array(),
 						comment: Hapi.types.String(),
 						username: Hapi.types.String().allow(''),

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -84,6 +84,7 @@ module.exports = function(app) {
 					payload: {
 						name: Hapi.types.String().required(),
 						timeout: Hapi.types.Number().integer(),
+						wait: Hapi.types.Number().integer(),
 						url: Hapi.types.String().required(),
 						username: Hapi.types.String().allow(''),
 						password: Hapi.types.String().allow(''),

--- a/test/integration/create-task.js
+++ b/test/integration/create-task.js
@@ -159,6 +159,52 @@ describe('POST /tasks', function() {
 
 	});
 
+	describe('with valid JSON and wait time', function() {
+		var newTask;
+
+		beforeEach(function(done) {
+			newTask = {
+				name: 'NPG Home',
+				url: 'nature.com',
+				timeout: '30000',
+				wait: 1000,
+				standard: 'WCAG2AA'
+			};
+			var req = {
+				method: 'POST',
+				endpoint: 'tasks',
+				body: newTask
+			};
+			this.navigate(req, done);
+		});
+
+		it('should add the new task to the database', function(done) {
+			this.app.model.task.collection.findOne(newTask, function(err, task) {
+				assert.isDefined(task);
+				done(err);
+			});
+		});
+
+		it('should send a 201 status', function() {
+			assert.strictEqual(this.last.status, 201);
+		});
+
+		it('should send a location header pointing to the new task', function() {
+			var taskUrl = 'http://' + this.last.request.uri.host + '/tasks/' + this.last.body.id;
+			assert.strictEqual(this.last.response.headers.location, taskUrl);
+		});
+
+		it('should output a JSON representation of the new task', function() {
+			assert.isDefined(this.last.body.id);
+			assert.strictEqual(this.last.body.name, newTask.name);
+			assert.strictEqual(this.last.body.url, newTask.url);
+			assert.strictEqual(this.last.body.standard, newTask.standard);
+			assert.deepEqual(this.last.body.wait, newTask.wait);
+			assert.deepEqual(this.last.body.ignore, []);
+		});
+
+	});
+
 	describe('with invalid name', function() {
 
 		beforeEach(function(done) {

--- a/test/integration/edit-task-by-id.js
+++ b/test/integration/edit-task-by-id.js
@@ -30,6 +30,7 @@ describe('PATCH /tasks/{id}', function() {
 				taskEdits = {
 					name: 'New Name',
 					timeout: '30000',
+					wait: 1000,
 					username: 'user',
 					password: 'access',
 					ignore: ['bar', 'baz'],
@@ -46,6 +47,13 @@ describe('PATCH /tasks/{id}', function() {
 			it('should update the task\'s name in the database', function(done) {
 				this.app.model.task.getById('abc000000000000000000001', function(err, task) {
 					assert.strictEqual(task.name, taskEdits.name);
+					done();
+				});
+			});
+
+			it('should update the task\'s wait time in the database', function(done) {
+				this.app.model.task.getById('abc000000000000000000001', function(err, task) {
+					assert.strictEqual(task.wait, taskEdits.wait);
 					done();
 				});
 			});


### PR DESCRIPTION
This web service change is required as part of changes to [pa11y-dashboard issue #127](https://github.com/springernature/pa11y-dashboard/issues/127)